### PR TITLE
feat: adicionar documentação Swagger/OpenAPI

### DIFF
--- a/src/main/java/com/example/HabitaCode/core/SwaggerConfig.java
+++ b/src/main/java/com/example/HabitaCode/core/SwaggerConfig.java
@@ -1,0 +1,18 @@
+package com.example.HabitaCode.core;
+
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.OpenAPI;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("API HabitaCode")
+                        .description("Documentação da API HabitaCode")
+                        .version("1.0"));
+    }
+}


### PR DESCRIPTION
Foi adicionada a configuração do Swagger utilizando OpenAPI 3 para documentar e facilitar a visualização e o teste dos endpoints da API HabitaCode. A configuração está centralizada no pacote core.config, permitindo futuras customizações e melhorias na apresentação da documentação.